### PR TITLE
Topic Pages and Theme Update

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,5 +8,5 @@ keywords: juju deploy kubernetes, juju kubernetes, kubernetes bundle, kubernetes
 analytics_id: UA-51016932-4
 repository: whitmo/bundle-kubernetes
 forkme_enabled: true
-url: http://chuckbutler.github.io/bundle-kubernetes/
+url: http://whitmo.github.io/bundle-kubernetes/
 #url: http://localhost:4000

--- a/_config.yml
+++ b/_config.yml
@@ -8,5 +8,5 @@ keywords: juju deploy kubernetes, juju kubernetes, kubernetes bundle, kubernetes
 analytics_id: UA-51016932-4
 repository: whitmo/bundle-kubernetes
 forkme_enabled: true
-url: http://whitmo.github.io/bundle-kubernetes/
+url: http://chuckbutler.github.io/bundle-kubernetes/
 #url: http://localhost:4000

--- a/_data/dev_nav.yml
+++ b/_data/dev_nav.yml
@@ -1,3 +1,5 @@
+- title: Interfaces
+  url: dev/interfaces.html
 - title: Contributing
   url: dev/contributing.html
 

--- a/_data/kubernetes_devnav.yml
+++ b/_data/kubernetes_devnav.yml
@@ -1,0 +1,15 @@
+- title: Services FAQ
+  url: https://github.com/GoogleCloudPlatform/kubernetes/wiki/Services-FAQ
+
+- title: Development Guide
+  url: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/devel/development.md
+
+- title: Pull Request Process
+  url: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/devel/pull-requests.md)
+
+- title: Releasing Kubernetes
+  url: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/devel/releasing.md
+
+- title: Kubernetes Wiki
+  url: https://github.com/GoogleCloudPlatform/kubernetes/wiki
+

--- a/_data/kubernetes_usernav.yml
+++ b/_data/kubernetes_usernav.yml
@@ -1,0 +1,16 @@
+- title: Getting started
+  url: https://jujucharms.com/docs/authors-intro
+
+- title: User FAQ
+  url: https://github.com/GoogleCloudPlatform/kubernetes/wiki/User-FAQ
+
+- title: Pods
+  url: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/pods.md
+
+- title: Replication Controllers
+  url: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/replication-controller.md
+
+- title: Services
+  url: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/services.md
+
+

--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -1,5 +1,5 @@
 - title: Juju
-  url: /info/juju.html
+  url: info/juju.html
 - title: Kubernetes
-  url: /info/kubernetes.html
+  url: info/kubernetes.html
 

--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -1,0 +1,5 @@
+- title: Juju
+  url: /info/juju.html
+- title: Kubernetes
+  url: /info/kubernetes.html
+

--- a/_includes/modules/topnav.html
+++ b/_includes/modules/topnav.html
@@ -13,52 +13,9 @@
               <div id="navbar-collapse-1" class="navbar-collapse collapse pull-right">
                 <ul class="nav navbar-nav">
                   <li class="dropdown yamm-fw"><a href="{{ site.url }}" class="active">Home</a></li>
-                  <li class="dropdown yamm-fw"> <a href="#" data-toggle="dropdown" class="dropdown-toggle">Juju Charms</a>
-                    <ul class="dropdown-menu">
-                      <li>
-                        <div class="yamm-content">
-                          <div class="row">
-
-                            <ul class="col-sm-6 col-md-4 list-unstyled two">
-                              <li>
-                                <p>Juju Solutions</p>
-                              </li>
-                              {% for link in site.data.jujucharms_solutionnav %}
-                              <li><a href="{{ link.url }}"><i class="fa fa-angle-right"></i>{{ link.title }}</a></li>
-                              {% endfor %}
-                            </ul>
-
-                            <ul class="col-sm-6 col-md-4 list-unstyled two">
-                              <li>
-                                <p>User Documentation</p>
-                              </li>
-                              {% for link in site.data.jujucharms_usernav %}
-                                <li><a href="{{ link.url }}"><i class="fa fa-angle-right"></i>{{ link.title }}</a></li>
-                              {% endfor %}
-                            </ul>
-
-                            <ul class="col-sm-6 col-md-4 list-unstyled two">
-                              <li>
-                                <p>Developer Documentation</p>
-                              </li>
-                              {% for link in site.data.jujucharms_devnav %}
-                                <li><a href="{{ link.url }}"><i class="fa fa-angle-right"></i>{{ link.title }}</a></li>
-                              {% endfor %}
-                            </ul>
-
-                          </div>
-                        </div>
-                      </li>
-                    </ul>
-                  </li>
-
-                  <li class="dropdown"><a href="#" data-toggle="dropdown" class="dropdown-toggle">{{ site.product }}</a>
-                    <ul class="dropdown-menu" role="menu">
-                      {% for link in site.data.product_nav %}
-                        <li><a href="{{ link.url }}"><i class="fa fa-angle-right"></i>{{ link.title }}</a></li>
-                      {% endfor %}
-                    </ul>
-                  </li>
+                {% for link in site.data.topnav %}
+                  <li><a href="{{ link.url }}">{{ link.title }}</a></li> 
+                {% endfor %}
                 </ul>
 
               </div>

--- a/_includes/modules/topnav.html
+++ b/_includes/modules/topnav.html
@@ -14,7 +14,7 @@
                 <ul class="nav navbar-nav">
                   <li class="dropdown yamm-fw"><a href="{{ site.url }}" class="active">Home</a></li>
                 {% for link in site.data.topnav %}
-                  <li><a href="{{ link.url }}">{{ link.title }}</a></li> 
+                  <li><a href="{{ site.url }}/{{ link.url }}">{{ link.title }}</a></li> 
                 {% endfor %}
                 </ul>
 

--- a/_pages/info-juju.md
+++ b/_pages/info-juju.md
@@ -1,0 +1,32 @@
+---
+layout: default
+title: Juju Resources
+category: Informational Pages
+permalink: /info/juju.html
+---
+
+Juju is a service orchestration tool developed and sponsored by Canonical. It
+interfaces with with existing configuration management solutions in a language
+agnostic way, and drives system deployments with a declarative, event driven
+model.
+
+If you are new to Juju, it may be helpful to begin with the Documentation for
+Juju, hosted at [juju.ubuntu.com/docs](http://juju.ubuntu.com/docs)
+
+#### Juju User Documentation
+
+<ul class="col-sm-6 col-md-4 ">
+{% for link in site.data.jujucharms_usernav %}
+    <p><a href="{{ link.url }}"><i class="fa fa-angle-right"></i> {{ link.title }}</a></p>
+{% endfor %}
+</ul>
+
+#### Juju Developer Documentation
+
+<ul class="col-sm-6 col-md-4 ">
+{% for link in site.data.jujucharms_devnav %}
+    <p><a href="{{ link.url }}"><i class="fa fa-angle-right"></i> {{ link.title }}</a></p>
+{% endfor %}
+</ul>
+
+

--- a/_pages/info-juju.md
+++ b/_pages/info-juju.md
@@ -13,17 +13,17 @@ model.
 If you are new to Juju, it may be helpful to begin with the Documentation for
 Juju, hosted at [juju.ubuntu.com/docs](http://juju.ubuntu.com/docs)
 
-#### Juju User Documentation
+#### User Documentation
 
-<ul class="col-sm-6 col-md-4 ">
+<ul>
 {% for link in site.data.jujucharms_usernav %}
     <p><a href="{{ link.url }}"><i class="fa fa-angle-right"></i> {{ link.title }}</a></p>
 {% endfor %}
 </ul>
 
-#### Juju Developer Documentation
+#### Developer Documentation
 
-<ul class="col-sm-6 col-md-4 ">
+<ul>
 {% for link in site.data.jujucharms_devnav %}
     <p><a href="{{ link.url }}"><i class="fa fa-angle-right"></i> {{ link.title }}</a></p>
 {% endfor %}

--- a/_pages/info-kubernetes.md
+++ b/_pages/info-kubernetes.md
@@ -1,0 +1,33 @@
+---
+layout: default
+title: Kubernetes Resources
+category: Informational Pages
+permalink: /info/kubernetes.html
+---
+
+Kubernetes is an open source system for managing containerized applications
+across multiple hosts, providing basic mechanisms for deployment, maintenance,
+and scaling of applications.
+
+#### User Documentation
+
+- [User FAQ](https://github.com/GoogleCloudPlatform/kubernetes/wiki/User-FAQ)
+- [Pods](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/pods.md)
+- [Replication Controllers](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/replication-controller.md)
+- [Services](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/services.md)
+
+#### Service Documentation
+
+- [Service FAQ](https://github.com/GoogleCloudPlatform/kubernetes/wiki/Services-FAQ)
+
+
+#### Developer Documentation
+
+- [Services FAQ](https://github.com/GoogleCloudPlatform/kubernetes/wiki/Services-FAQ)
+- [Development Guide](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/devel/development.md)
+- [Pull Request Process](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/devel/pull-requests.md)
+- [Releasing Kubernetes](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/devel/releasing.md)
+
+#### Wiki
+
+- [Kubernetes Wiki](https://github.com/GoogleCloudPlatform/kubernetes/wiki)

--- a/_pages/info-kubernetes.md
+++ b/_pages/info-kubernetes.md
@@ -9,25 +9,22 @@ Kubernetes is an open source system for managing containerized applications
 across multiple hosts, providing basic mechanisms for deployment, maintenance,
 and scaling of applications.
 
+
+
+
 #### User Documentation
 
-- [User FAQ](https://github.com/GoogleCloudPlatform/kubernetes/wiki/User-FAQ)
-- [Pods](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/pods.md)
-- [Replication Controllers](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/replication-controller.md)
-- [Services](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/services.md)
-
-#### Service Documentation
-
-- [Service FAQ](https://github.com/GoogleCloudPlatform/kubernetes/wiki/Services-FAQ)
+<ul>
+{% for link in site.data.kubernetes_usernav %}
+    <p><a href="{{ link.url }}"><i class="fa fa-angle-right"></i> {{ link.title }}</a></p>
+{% endfor %}
+</ul>
 
 
 #### Developer Documentation
+<ul>
+{% for link in site.data.kubernetes_devnav %}
+    <p><a href="{{ link.url }}"><i class="fa fa-angle-right"></i> {{ link.title }}</a></p>
+{% endfor %}
+</ul>
 
-- [Services FAQ](https://github.com/GoogleCloudPlatform/kubernetes/wiki/Services-FAQ)
-- [Development Guide](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/devel/development.md)
-- [Pull Request Process](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/devel/pull-requests.md)
-- [Releasing Kubernetes](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/devel/releasing.md)
-
-#### Wiki
-
-- [Kubernetes Wiki](https://github.com/GoogleCloudPlatform/kubernetes/wiki)


### PR DESCRIPTION
Removes the "hidden data by dropdown" approach and rolls up with the following considerations:
-  Topic pages that link externally should be clear that the information is hosted elsewhere
- Topic pages that are using HTML styling for the content should be data-driven, because I hate writing HTML by hand
- Includes stub page for interfaces (with no data as of yet)
