### PR TITLE
Adds release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,15 @@ func_test: virtualenv
 	@echo functional tests...
 	@.venv/bin/bundletester -v -F -l DEBUG
 
+release: check-path
+	@.venv/bin/pip install git-vendor
+	@.venv/bin/git-vendor sync -d $KUBERNETES_BUNDLE_BZR
+
+check-path:
+	ifndef KUBERNETES_BUNDLE_BZR
+		$(error KUBERNETES_BUNDLE_BZR is undefined)
+	endif
+
 clean:
 	rm -rf .venv
 	find -name *.pyc -delete


### PR DESCRIPTION
`check-path` will sniff the ENV for $KUBERNETES_BUNDLE_BZR envvar. If it
is not found, it will not allow the release process to continue.

`make release` will kick off the release process of installing the
git-vendor python module, and passing off the $KUBERNETES_BUNDLE_BZR env
location to git-vendor. _note_ the constraints of git-vendor still
apply. The repository must have a tag to export and cannot be in a dirty
state.

This is CI-capable so long as CI doesn't alter any files in the
repository prior to "blessing" a release. At which point, we can
automate the release process by setting the ENVVAR for the job.
